### PR TITLE
Added Query Escape to provider.go

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -99,7 +100,11 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		password := d.Get("password").(string)
 		tenant := d.Get("tenant").(string)
 		grant_type := d.Get("grant_type").(string)
-		timeout, err := time.ParseDuration(d.Get("timeout").(string))
+		timeout, err := time.ParseDuration(d.Get("timeout").(string));
+
+		username = url.QueryEscape(username);
+		password = url.QueryEscape(password);
+		tenant = url.QueryEscape(tenant);
 
 		var base_url string
 		if strings.Contains(tenant, "//") {


### PR DESCRIPTION
It prevents special characters from breaking the request. 

Requested in [Issue  #3](https://github.com/kellystuard/terraform-provider-tss/issues/3)